### PR TITLE
groonga: specify --sbindir and cleanup /var/run

### DIFF
--- a/abs/groonga/PKGBUILD
+++ b/abs/groonga/PKGBUILD
@@ -14,6 +14,7 @@ build() {
     ./configure --prefix=/usr \
     --localstatedir=/var \
     --sysconfdir=/etc \
+    --sbindir=/usr/bin \
     --with-default-encoding=utf8 \
     --with-zlib \
     --with-lz4 \
@@ -29,5 +30,8 @@ build() {
 package() {
     cd $srcdir/$pkgname-$pkgver
     make DESTDIR="$pkgdir" install
+
+    # cleanup
+    rm -r "${pkgdir}/var/run"
 }
 sha1sums=('a3bdc46b980e44dae74dae78777919691cf1b4f0')


### PR DESCRIPTION
installing latest `aur/groonga` fails with errors:

```
==> Continue installing groonga ? [Y/n]
==> [v]iew package contents [c]heck package with namcap
==> ---------------------------------------------------
==> 
loading packages...
resolving dependencies...
looking for conflicting packages...

Packages (1) groonga-5.0.3-2

Total Installed Size:  15.60 MiB

:: Proceed with installation? [Y/n] 
(1/1) checking keys in keyring                                                   [##############################################] 100%
(1/1) checking package integrity                                                 [##############################################] 100%
(1/1) loading package files                                                      [##############################################] 100%
(1/1) checking for file conflicts                                                [##############################################] 100%
error: failed to commit transaction (conflicting files)
groonga: /usr/sbin exists in filesystem
groonga: /var/run exists in filesystem
Errors occurred, no packages were upgraded.
```

to fix these errors, following statements are needed:
### make with `--sbindir=/usr/bin`

install all executables to /usr/bin
### `rm -r "${pkgdir}/var/run"` after `make install`

creating `/var/run/groonga` when installing seems to be not good way, so clean up that.
note that [extra/apache does like that (see the bottom of file)](https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/apache).
